### PR TITLE
Fix for CVE-2024-32879

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ lxml
 Pygments
 mistune<2
 social-auth-core==4.3.0
-social-auth-app-django==5.0.0
+social-auth-app-django==5.4.1
 pytz
 django-statici18n
 pika


### PR DESCRIPTION
Upgraded the package `social-auth-app-django==5.0.0 => social-auth-app-django==5.4.1`